### PR TITLE
VCST-5248: Bump action versions

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   gitops-publish-platform:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       DOCKER_LOGIN: vcmp-token
       DOCKER_PASSWORD: ${{ secrets.VCMP_ACR_DOCKER_PASSWORD }}
@@ -22,7 +22,7 @@ jobs:
       ARGO_APP_NAME: ${{ github.ref_name }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Install vc-build
       run: |
@@ -49,7 +49,7 @@ jobs:
         docker build --build-arg PLATFORM_IMAGE=${{ env.PLATFORM_IMAGE }} --build-arg PLATFORM_TAG=${{ env.PLATFORM_TAG }} -t ${{env.PLATFORM_IMAGE_NAME}} ${{env.DOCKERFILE_PATH}}
 
     - name: Docker Login
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.CONTAINER_REGISTRY }}
         username: ${{ env.DOCKER_LOGIN }}

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -10,10 +10,10 @@ on:
 
 jobs:
   gitops-publish-infra:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
   
     - name: Install vc-build
       run: |

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -10,14 +10,14 @@ on:
 
 jobs:
   gitops:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       ARGO_APP_NAME: vcmp-dev
       STORYBOOK_TAG: ''
       CLOUD_URL: https://portal.virtocommerce.cloud
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
    
       - name: Install vc-build
         run: |

--- a/.github/workflows/deploy-theme.yml
+++ b/.github/workflows/deploy-theme.yml
@@ -13,13 +13,13 @@ jobs:
     strategy:
       matrix:
         store: [B2B-store]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       ARGO_APP_NAME: ${{ github.ref_name }}
       ARTIFACT_URL: ''
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
    
       - name: Install vc-build
         run: |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only CI workflow changes with no application or deployment logic edits; minor risk from runner/action behavior differences on the next run.
> 
> **Overview**
> Updates four cloud deployment workflows (`deploy-backend`, `deploy-infra`, `deploy-storybook`, `deploy-theme`) to run on **`ubuntu-24.04`** instead of `ubuntu-22.04` or `ubuntu-latest`, and bumps **`actions/checkout`** from **v4** to **v7** in each.
> 
> The backend workflow also upgrades **`docker/login-action`** from **v3** to **v4**. Deployment steps and secrets usage are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 910ede6af2ca1fa0dd64dfec2bf1870e8a47a205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->